### PR TITLE
178068 - Tarefas dia 26/04/2024

### DIFF
--- a/html_bloco_lista_de_videos_IMP.py
+++ b/html_bloco_lista_de_videos_IMP.py
@@ -8,7 +8,7 @@ import html_bloco_titulo
 def gera(lista_ids_vid):
   # Linha de cabeçalho:
   est_cab = html_estilo_cabecalho_de_tabela.gera()
-  cabs_raw = ['Usuário', 'Arquivo', 'Título', 'Data', 'Duração', 'Largura', 'Altura']
+  cabs_raw = ['Título', 'Data', 'Duração', 'Largura', 'Altura']
   cabecalho = [].copy()
   for cb in cabs_raw:
     cabecalho.append(html_elem_div.gera(est_cab, cb))
@@ -21,8 +21,11 @@ def gera(lista_ids_vid):
     # Gera uma lista de fragmentos HTML com as informacoes desse video
     res_campos = html_linha_resumo_de_video.gera(vid)
 
-    # Adiciona essa lista à lista de linhas para a tabela HTML:
-    linhas.append(res_campos)
+    # Adiciona essa lista à lista de linhas para a tabela HTML.
+    # Selecionamos apenas os elementos que queremos.
+    # Nesse caso, todos de res_campos exceto ht_usr, que é o usuário e não devemos mostrar.
+    # Dessa forma mantemos a informação completa em html_linha_resumo_de_video e res_campos caso seja necessário eventualmente.
+    linhas.append(res_campos[1:])
 
   # Gera a tabela HTML a partir da lista de linhas
   ht_tabela = html_elem_table.gera(linhas, cabecalho)

--- a/html_linha_resumo_de_video_IMP.py
+++ b/html_linha_resumo_de_video_IMP.py
@@ -31,6 +31,6 @@ def gera(vid):
 
   # TODO: ver_video precisa ser implementado
   bt_arg = {'video': obj_video.obtem_identificador(vid)}
-  bt_ver = html_elem_button_simples.gera("Ver", "ver_video", bt_arg, "#eeeeee")
+  bt_ver = html_elem_button_simples.gera("Ver", "ver_video", bt_arg, "#ffcc88")
 
   return [ht_usr, ht_titulo, ht_data, ht_duracao, ht_largura, ht_altura, bt_ver]

--- a/obj_video_IMP.py
+++ b/obj_video_IMP.py
@@ -62,7 +62,7 @@ def cria(atrs):
 
   # Data de upload:
   if 'data' in atrs: raise ErroAtrib("data não pode ser especificada")
-  data = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S %z")
+  data = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
   atrs['data'] = data
 
   # Determina o identificador esperado do vídeo:

--- a/relatorios/2024-04-26/178068.txt
+++ b/relatorios/2024-04-26/178068.txt
@@ -1,0 +1,17 @@
+Oi Professor, boa noite!
+
+Fiquei encarregado das seguintes tarefas hoje:
+> comando_buscar_videos_de_usuario: omitir a coluna "Usuário" da tabela. Acertar o cabecalho das colunas. Botão "Ver" deve ser amarelo como nas outras páginas. Corrigir a data para mostrar zona "UTC" em vez de "+0000".
+
+Para omitir a coluna "Usuário" da tabela, modifiquei o html_bloco_lista_de_videos_IMP.py para que não fosse selecionado o ht_usr da lista de campos res_campos. Optei por manter a lista de campos gerada por html_linha_resumo_de_video para o caso de precisarmos dessa informação para alguma outra função do site. Caso contrário, poderiamos mesmo remover essa informação diretamente do html_linha_resumo_video_IMP.py.
+
+Para acertar o cabeçalho das colunas, modifiquei o módulo html_bloco_lista_de_videos_IMP.py para que cabs_raw = ['Título', 'Data', 'Duração', 'Largura', 'Altura'] ficasse da forma especificada.
+    
+Para o botão "Ver" que deveria ser amarelo como padronizado nas outras páginas, modifiquei o html_linha_resumo_video_IMP.py:
+def gera(texto, URL, cmd_args, cor_fundo): - a função de geração de botão recebe a cor como parâmetro.
+bt_ver = html_elem_button_simples.gera("Ver", "ver_video", bt_arg, "#ffcc88"): alterei a cor para o mesmo amarelo que encontrei no menu principal do site, no botão "Sair" especificado emhtml_bloco_menu_geral_IMP (cor_bt_sair = "#ffcc88").
+
+Para corrigir a data para mostrar zona "UTC" em vez de "+0000", alterei o obj_video_IMP.py, que define os atributos de vídeo.
+A documentação do strftime indicava que poderiamos utilizar o %Z no lugar do %z para apresentar a zona no formato "UTC".
+ 
+Bom final de semana Professor. Qualquer coisa o senhor pode me chamar.


### PR DESCRIPTION
Fiquei encarregado das seguintes tarefas hoje:
> comando_buscar_videos_de_usuario: omitir a coluna "Usuário" da tabela. Acertar o cabecalho das colunas. Botão "Ver" deve ser amarelo como nas outras páginas. Corrigir a data para mostrar zona "UTC" em vez de "+0000".

Para omitir a coluna "Usuário" da tabela, modifiquei o html_bloco_lista_de_videos_IMP.py para que não fosse selecionado o ht_usr da lista de campos res_campos. Optei por manter a lista de campos gerada por html_linha_resumo_de_video para o caso de precisarmos dessa informação para alguma outra função do site. Caso contrário, poderiamos mesmo remover essa informação diretamente do html_linha_resumo_video_IMP.py.

Para acertar o cabeçalho das colunas, modifiquei o módulo html_bloco_lista_de_videos_IMP.py para que cabs_raw = ['Título', 'Data', 'Duração', 'Largura', 'Altura'] ficasse da forma especificada.
    
Para o botão "Ver" que deveria ser amarelo como padronizado nas outras páginas, modifiquei o html_linha_resumo_video_IMP.py:
def gera(texto, URL, cmd_args, cor_fundo): - a função de geração de botão recebe a cor como parâmetro.
bt_ver = html_elem_button_simples.gera("Ver", "ver_video", bt_arg, "#ffcc88"): alterei a cor para o mesmo amarelo que encontrei no menu principal do site, no botão "Sair" especificado emhtml_bloco_menu_geral_IMP (cor_bt_sair = "#ffcc88").

Para corrigir a data para mostrar zona "UTC" em vez de "+0000", alterei o obj_video_IMP.py, que define os atributos de vídeo.
A documentação do strftime indicava que poderiamos utilizar o %Z no lugar do %z para apresentar a zona no formato "UTC".