### PR TITLE
RA: 074126 Tarefa 2024_05_24. Relatorio e correcao de nome de atributo em modulos sobre data de sessao

### DIFF
--- a/comando_ver_sessao_IMP.py
+++ b/comando_ver_sessao_IMP.py
@@ -1,5 +1,6 @@
 import html_pag_ver_sessao
 import obj_sessao
+import html_pag_principal # Acrescentado, estava faltando.
 
 def processa(ses, cmd_args):
   erros = []

--- a/html_bloco_dados_de_sessao_IMP.py
+++ b/html_bloco_dados_de_sessao_IMP.py
@@ -22,7 +22,8 @@ def gera(ses):
   dados_linhas = \
     (
       ( "ID da sessão",       "text", 'sessao',     False, None, ),
-      ( "Criada em",          "text", 'data_login', False, None, ),
+      #( "Criada em",          "text", 'data_login', False, None, ), # Original/Old
+      ( "Criada em",          "text", 'criacao', False, None, ),# Alterado data_login para "criacao" conforme obj_sessao_IMP
       ( "Dono",               "text", 'dono',       False, None, ),
       ( "Cookie",             "text", 'cookie',     False, None, ),
       ( "Status",             "text", 'aberta',     False, None, ),

--- a/obj_sessao_IMP.py
+++ b/obj_sessao_IMP.py
@@ -39,7 +39,8 @@ def inicializa_modulo(limpa):
   colunas = \
     (
       ( 'dono',     obj_usuario.Classe, 'TEXT',    False ), # Objeto/id do usuário logado na sessão.
-      ( 'criacao', type("foo"),        'TEXT',    False ), # Momento de criação da sessão.
+      ( 'criacao', type("foo"),        'TEXT',    False ), # Momento de criação da sessão. # Original/Old
+      #( 'data_login', type("foo"),        'TEXT',    False ), # Momento de criação da sessão. # Alterado criacao para "data_login" conforme html_bloco_dados_de_sessao_IMP
       ( 'aberta',  type(False),        'INTEGER', False ), # Estado da sessao (1 = aberta).
       ( 'cookie',  type("foo"),        'TEXT',    False ), # Cookie da sessao.
     )

--- a/relatorios/074126.txt
+++ b/relatorios/074126.txt
@@ -1,1 +1,19 @@
 Relatorio - 074126
+TAREFAS:
+
+074126 [Logar como administrador ("primeiro@gmail.com", senha "U-00000001")] Menu "Buscar sessões" > Entrar "Usuario: U-00000002" > Botão "Buscar" > "Botão "Ver" : A data de criação não aparece, em vez disso tem um campo "readonly" em branco. Corrija.
+
+1 Implementação:
+O erro se deu porque o nome correspondente ao atributo de data da sessão estava diferente nos módulos "html_bloco_dados_de_sessao_IMP.py" (data_login) e "obj_sassao_IMP.py" (criacao).
+Para corrigir, modifiquei o nome do atributo de "html_bloco_dados_de_sessao_IMP.py" para criacao para ficar igual ao de "obj_sessao_IMP.py".
+Também tentei a imlementação alternativa de modificar o atributo em "obj_sassao_IMP.py", mas não funcionou.
+
+2 Testes dos módulos envolvidos:
+2.1 ./testa.sh comando_ver_sessao terminado normalmente
+
+2.2 ./testa.sh html_bloco_dados_de_sessao terminado normalmente
+
+2.3 ./testa.sh obj_sessao terminado normalmente
+
+3 Impressões sobre tarefa do dia 24 de maio de 2024:
+Tive bastante facilidade da tarefa proposta hoje.


### PR DESCRIPTION
O erro se deu porque o nome correspondente ao atributo de data da sessão estava diferente nos módulos "html_bloco_dados_de_sessao_IMP.py" (data_login) e "obj_sassao_IMP.py" (criacao).
Para corrigir, modifiquei o nome do atributo de "html_bloco_dados_de_sessao_IMP.py" para criacao para ficar igual ao de "obj_sessao_IMP.py".
Também tentei a imlementação alternativa de modificar o atributo em "obj_sassao_IMP.py", mas não funcionou.

Testes executados com sucesso.